### PR TITLE
Codex: Rename variable to avoid shadowing the confirm function

### DIFF
--- a/src/components/ArchiveManager.jsx
+++ b/src/components/ArchiveManager.jsx
@@ -70,8 +70,8 @@ export default function ArchiveManager() {
 
   const handleClear = () => {
     if (locked) return;
-    const confirm = window.confirm('Delete all archived weeks? This cannot be undone.');
-    if (confirm) {
+    const confirmed = window.confirm('Delete all archived weeks? This cannot be undone.');
+    if (confirmed) {
       localStorage.removeItem('fitnessArchive');
       alert('Archive cleared.');
     }


### PR DESCRIPTION
## Summary
- rename `confirm` variable in ArchiveManager to `confirmed`

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: HTMLCanvasElement.getContext not implemented)*

## Summary by Sourcery

Enhancements:
- Change the `confirm` variable to `confirmed` when handling archive clearing in `handleClear`.